### PR TITLE
ESP32: Remove old modxpt2046.c and modILI9341.c

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -387,9 +387,10 @@ LIB_SRC_C += \
 	lib/lv_bindings/driver/esp32/modlvesp32.c \
 	lib/lv_bindings/driver/esp32/modrtch.c \
 	lib/lv_bindings/driver/esp32/espidf.c \
-	$(ESPIDFMOD_MODULE) \
-	lib/lv_bindings/driver/esp32/modxpt2046.c \
-	lib/lv_bindings/driver/esp32/modILI9341.c \
+	$(ESPIDFMOD_MODULE)
+	
+#	lib/lv_bindings/driver/esp32/modxpt2046.c
+#	lib/lv_bindings/driver/esp32/modILI9341.c
 
 DRIVERS_SRC_C = $(addprefix drivers/,\
 	bus/softspi.c \


### PR DESCRIPTION
modxpt2046.c and modILI9341.c C drivers were replace by ili9XXX.py and ili9XXX.py Python drivers.
Remove them from Makefile.

Fixes #93